### PR TITLE
feat: add request-id log context propagation

### DIFF
--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -3,8 +3,29 @@
 from __future__ import annotations
 
 import logging
+from contextvars import ContextVar, Token
 
+_REQUEST_ID: ContextVar[str] = ContextVar("request_id", default="-")
 _CONFIGURED = False
+
+
+class RequestContextFilter(logging.Filter):
+    """Inject request context fields into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Attach request id to record and allow emission."""
+        record.request_id = _REQUEST_ID.get()
+        return True
+
+
+def set_request_id(request_id: str) -> Token[str]:
+    """Set request id in logging context and return reset token."""
+    return _REQUEST_ID.set(request_id)
+
+
+def reset_request_id(token: Token[str]) -> None:
+    """Restore prior request id context with provided token."""
+    _REQUEST_ID.reset(token)
 
 
 def configure_logging(level_name: str = "INFO") -> None:
@@ -20,8 +41,12 @@ def configure_logging(level_name: str = "INFO") -> None:
     level = getattr(logging, level_name.upper(), logging.INFO)
     logging.basicConfig(
         level=level,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        format="%(asctime)s %(levelname)s %(name)s [request_id=%(request_id)s] %(message)s",
     )
+    context_filter = RequestContextFilter()
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        handler.addFilter(context_filter)
     _CONFIGURED = True
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import uuid
 from collections import deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from contextvars import Token
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -15,7 +16,12 @@ from pydantic import BaseModel, Field
 from src.config import settings, validate_runtime_settings
 from src.ingest import IngestResult, ingest_from_hf, ingest_topic
 from src.job_store import JobStore
-from src.logging_utils import configure_logging, get_logger
+from src.logging_utils import (
+    configure_logging,
+    get_logger,
+    reset_request_id,
+    set_request_id,
+)
 from src.neo4j_client import neo4j_client
 from src.retrieve import query_graph
 
@@ -183,6 +189,13 @@ def _guard(request: Request, x_api_key: str | None = Header(default=None)) -> No
     _enforce_rate_limit(request)
 
 
+def _with_request_context(request: Request) -> tuple[str, Token[str]]:
+    """Attach request id into logging context and return id plus token."""
+    request_id = _request_id(request)
+    token = set_request_id(request_id)
+    return request_id, token
+
+
 @app.get("/health")
 def health() -> dict:
     """Return basic liveness status."""
@@ -230,33 +243,37 @@ def metrics() -> str:
 @app.post("/ingest", dependencies=[Depends(_guard)])
 def ingest(req: IngestRequest, request: Request) -> dict:
     """Ingest one or more Wikipedia topics."""
-    request_id = _request_id(request)
-    results = []
-    for topic in req.topics:
-        try:
-            result = ingest_topic(topic)
-        except (ValueError, RuntimeError) as exc:
-            logger.warning("Topic ingest failed", extra={"request_id": request_id, "topic": topic})
-            raise HTTPException(status_code=400, detail=f"Failed ingest for '{topic}': {exc}") from exc
-        results.append(_serialize_ingest_result(result))
+    _request_id_value, token = _with_request_context(request)
+    try:
+        results = []
+        for topic in req.topics:
+            try:
+                result = ingest_topic(topic)
+            except (ValueError, RuntimeError) as exc:
+                logger.warning("Topic ingest failed", extra={"topic": topic})
+                raise HTTPException(status_code=400, detail=f"Failed ingest for '{topic}': {exc}") from exc
+            results.append(_serialize_ingest_result(result))
 
-    logger.info("Topic ingest completed", extra={"request_id": request_id, "count": len(results)})
-    return {"ingested": results}
+        logger.info("Topic ingest completed", extra={"count": len(results)})
+        return {"ingested": results}
+    finally:
+        reset_request_id(token)
 
 
 @app.post("/query", dependencies=[Depends(_guard)])
 def query(req: QueryRequest, request: Request) -> dict:
     """Query graph and return deterministic answer plus citations."""
-    request_id = _request_id(request)
+    _request_id_value, token = _with_request_context(request)
     started = time.perf_counter()
     try:
         result = query_graph(req.question, req.top_k)
     except RuntimeError as exc:
-        logger.exception("Query failed", extra={"request_id": request_id})
+        logger.exception("Query failed")
         raise HTTPException(status_code=500, detail=f"Query failed: {exc}") from exc
-
-    elapsed_ms = int((time.perf_counter() - started) * 1000)
-    logger.info("Query completed", extra={"request_id": request_id, "duration_ms": elapsed_ms})
+    finally:
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        logger.info("Query completed", extra={"duration_ms": elapsed_ms})
+        reset_request_id(token)
 
     return {
         "answer": result.answer,
@@ -267,7 +284,7 @@ def query(req: QueryRequest, request: Request) -> dict:
 @app.post("/ingest/hf", dependencies=[Depends(_guard)])
 def ingest_hf(req: HFDatasetIngestRequest, request: Request) -> dict:
     """Ingest a bounded sample directly from HF dataset (synchronous)."""
-    request_id = _request_id(request)
+    _request_id_value, token = _with_request_context(request)
     try:
         results = ingest_from_hf(
             config_name=req.config_name,
@@ -276,10 +293,12 @@ def ingest_hf(req: HFDatasetIngestRequest, request: Request) -> dict:
             streaming=req.streaming,
         )
     except RuntimeError as exc:
-        logger.warning("HF ingest failed", extra={"request_id": request_id})
+        logger.warning("HF ingest failed")
         raise HTTPException(status_code=400, detail=f"Failed HF ingestion: {exc}") from exc
+    finally:
+        reset_request_id(token)
 
-    logger.info("HF ingest completed", extra={"request_id": request_id, "count": len(results)})
+    logger.info("HF ingest completed", extra={"count": len(results)})
     return {"ingested": [_serialize_ingest_result(r) for r in results]}
 
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+
+import src.logging_utils as lu
+
+
+def test_request_context_filter_injects_request_id() -> None:
+    filt = lu.RequestContextFilter()
+    token = lu.set_request_id("rid-123")
+    try:
+        record = logging.LogRecord(
+            name="x",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+        assert filt.filter(record) is True
+        assert getattr(record, "request_id") == "rid-123"
+    finally:
+        lu.reset_request_id(token)
+
+
+def test_set_and_reset_request_id_roundtrip() -> None:
+    t1 = lu.set_request_id("rid-a")
+    try:
+        assert lu._REQUEST_ID.get() == "rid-a"
+    finally:
+        lu.reset_request_id(t1)
+
+    assert lu._REQUEST_ID.get() == "-"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,3 +80,30 @@ def test_rate_limit_rejects_excess(monkeypatch) -> None:
         resp = client.post("/query", json={"question": "hello world", "top_k": 1})
 
     assert resp.status_code == 429
+
+
+def test_with_request_context_sets_and_resets_request_id(monkeypatch) -> None:
+    captured = {"value": None}
+
+    def _fake_set_request_id(value: str):
+        captured["value"] = value
+        return "token"
+
+    def _fake_reset_request_id(token):
+        captured["reset"] = token
+
+    monkeypatch.setattr(main, "set_request_id", _fake_set_request_id)
+    monkeypatch.setattr(main, "reset_request_id", _fake_reset_request_id)
+
+    class _Client:
+        host = "127.0.0.1"
+
+    class _Req:
+        headers = {"X-Request-ID": "rid-001"}
+        client = _Client()
+
+    rid, token = main._with_request_context(_Req())
+
+    assert rid == "rid-001"
+    assert token == "token"
+    assert captured["value"] == "rid-001"


### PR DESCRIPTION
## Summary

Add request-scoped log context so all log lines can include a request identifier, improving traceability across API flow.

## Changes

- `src/logging_utils.py`
  - add `RequestContextFilter`
  - add contextvar-backed request id propagation
  - add helpers: `set_request_id`, `reset_request_id`
  - update log format to include `request_id`
- `src/main.py`
  - add `_with_request_context` helper
  - wire request context into `/ingest`, `/query`, `/ingest/hf`
- tests
  - add `tests/test_logging_utils.py`
  - extend `tests/test_main.py` for context helper behavior

## Validation

- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest`

All pass locally (42 tests, coverage gate still passing).
