### PR TITLE
feat: structured JSON logging mode + request context fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ RATE_LIMIT_PER_MINUTE=120
 
 # Logging
 LOG_LEVEL=INFO
+JSON_LOGS=false
 
 # Gemini
 GEMINI_KEY_FILE=.gemini_key.txt

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,6 +29,12 @@ Optional:
 - `APP_API_KEY` to require `X-API-Key` on protected endpoints.
 - `RATE_LIMIT_PER_MINUTE` for per-client request throttling.
 
+## Logging
+
+- `LOG_LEVEL` controls verbosity (`DEBUG`, `INFO`, `WARNING`, ...).
+- `JSON_LOGS=true` enables structured one-line JSON logs.
+- Log records include `request_id` and relevant operational fields when available (e.g. `duration_ms`, `job_id`, `status`).
+
 ## Readiness and metrics
 
 - `GET /ready` verifies Neo4j connectivity and reports dependency status.

--- a/src/config.py
+++ b/src/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     app_api_key: str | None = None
     rate_limit_per_minute: int = 120
     log_level: str = "INFO"
+    json_logs: bool = False
     require_gemini_key_on_startup: bool = False
 
     @field_validator("rate_limit_per_minute")

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from contextvars import ContextVar, Token
+from datetime import datetime, timezone
 
 _REQUEST_ID: ContextVar[str] = ContextVar("request_id", default="-")
 _CONFIGURED = False
@@ -18,6 +20,30 @@ class RequestContextFilter(logging.Filter):
         return True
 
 
+class JsonFormatter(logging.Formatter):
+    """Render log records as one-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Serialize logging record as JSON."""
+        payload = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "request_id": getattr(record, "request_id", "-"),
+            "message": record.getMessage(),
+        }
+
+        for key in ("duration_ms", "count", "topic", "job_id", "status", "error"):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
 def set_request_id(request_id: str) -> Token[str]:
     """Set request id in logging context and return reset token."""
     return _REQUEST_ID.set(request_id)
@@ -28,25 +54,34 @@ def reset_request_id(token: Token[str]) -> None:
     _REQUEST_ID.reset(token)
 
 
-def configure_logging(level_name: str = "INFO") -> None:
+def configure_logging(level_name: str = "INFO", json_logs: bool = False) -> None:
     """Configure process-wide logging once.
 
     Args:
         level_name: Logging level name (for example ``INFO`` or ``DEBUG``).
+        json_logs: When true, emit one-line JSON log records.
     """
     global _CONFIGURED
     if _CONFIGURED:
         return
 
     level = getattr(logging, level_name.upper(), logging.INFO)
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(name)s [request_id=%(request_id)s] %(message)s",
-    )
+    logging.basicConfig(level=level)
+
+    formatter: logging.Formatter
+    if json_logs:
+        formatter = JsonFormatter()
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s [request_id=%(request_id)s] %(message)s"
+        )
+
     context_filter = RequestContextFilter()
     root_logger = logging.getLogger()
     for handler in root_logger.handlers:
+        handler.setFormatter(formatter)
         handler.addFilter(context_filter)
+
     _CONFIGURED = True
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ from src.neo4j_client import neo4j_client
 from src.retrieve import query_graph
 
 
-configure_logging(settings.log_level)
+configure_logging(settings.log_level, json_logs=settings.json_logs)
 logger = get_logger(__name__)
 
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 
 import src.logging_utils as lu
@@ -32,3 +33,24 @@ def test_set_and_reset_request_id_roundtrip() -> None:
         lu.reset_request_id(t1)
 
     assert lu._REQUEST_ID.get() == "-"
+
+
+def test_json_formatter_emits_json_payload() -> None:
+    formatter = lu.JsonFormatter()
+    record = logging.LogRecord(
+        name="svc",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="hello world",
+        args=(),
+        exc_info=None,
+    )
+    record.request_id = "rid-88"
+    record.duration_ms = 15
+    payload = json.loads(formatter.format(record))
+
+    assert payload["logger"] == "svc"
+    assert payload["request_id"] == "rid-88"
+    assert payload["message"] == "hello world"
+    assert payload["duration_ms"] == 15

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,3 +107,20 @@ def test_with_request_context_sets_and_resets_request_id(monkeypatch) -> None:
     assert rid == "rid-001"
     assert token == "token"
     assert captured["value"] == "rid-001"
+
+
+def test_main_uses_json_log_setting_for_configure_logging(monkeypatch) -> None:
+    calls = {}
+
+    def _fake_configure_logging(level_name: str, json_logs: bool = False):
+        calls["level_name"] = level_name
+        calls["json_logs"] = json_logs
+
+    monkeypatch.setattr(main, "configure_logging", _fake_configure_logging)
+    monkeypatch.setattr(main.settings, "log_level", "DEBUG")
+    monkeypatch.setattr(main.settings, "json_logs", True)
+
+    main.configure_logging(main.settings.log_level, json_logs=main.settings.json_logs)
+
+    assert calls["level_name"] == "DEBUG"
+    assert calls["json_logs"] is True


### PR DESCRIPTION
## Summary

Implement structured JSON logging mode inspired by production-style observability patterns from the reference codebase, while keeping current stdlib logging stack.

## Changes

- Add JSON formatter in `src/logging_utils.py`
  - one-line JSON logs
  - includes `ts`, `level`, `logger`, `request_id`, `message`
  - includes key operation fields when available (`duration_ms`, `count`, `topic`, `job_id`, `status`, `error`)
- Extend logging configuration:
  - `configure_logging(level_name, json_logs=...)`
  - preserve default text logs
- Add config switch:
  - `Settings.json_logs: bool = False`
  - `.env.example` includes `JSON_LOGS=false`
- Wire main app logging config:
  - `configure_logging(settings.log_level, json_logs=settings.json_logs)`
- Update docs:
  - `docs/operations.md` logging section for `LOG_LEVEL` + `JSON_LOGS`
- Tests:
  - validate JSON formatter output shape
  - maintain request context propagation tests

## Validation

- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest`

All pass locally (44 tests, coverage gate passing).
