### PR TITLE
chore: add Makefile, templates, CODEOWNERS, and modes docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Chunporo

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Report a reproducible problem
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+## Steps to reproduce
+
+## Expected behavior
+
+## Environment
+- OS:
+- Python:
+- Commit/tag:
+
+## Logs / screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Propose an improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+## Proposed solution
+
+## Alternatives considered
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+## Changes
+
+## Validation
+- [ ] `uv run ruff check src tests`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest`
+
+## Checklist
+- [ ] Backward compatibility preserved (or documented)
+- [ ] Docs updated if needed
+- [ ] Tests added/updated

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: help install check lint typecheck test docs run
+
+help:
+	@echo "Available targets:"
+	@echo "  install   - install dependencies"
+	@echo "  run       - run API server"
+	@echo "  lint      - run ruff"
+	@echo "  typecheck - run mypy"
+	@echo "  test      - run pytest"
+	@echo "  docs      - build docs"
+	@echo "  check     - run lint + typecheck + test"
+
+install:
+	uv sync --all-groups
+
+run:
+	uv run uvicorn src.main:app --reload --port 8000
+
+lint:
+	uv run ruff check src tests
+
+typecheck:
+	uv run mypy src
+
+test:
+	uv run pytest
+
+docs:
+	uv run mkdocs build
+
+check: lint typecheck test

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Backend demo that ingests Wikipedia content into Neo4j and answers questions wit
 
 ## Highlights
 
+## Modes
+
+- **Ingest mode**: build graph context from Wikipedia topics or HF dataset (`/ingest`, `/ingest/hf`, async jobs).
+- **Query mode**: answer user questions with validated Cypher and hybrid fallback retrieval (`/query`).
+- **Export mode**: planned endpoint for graph snapshot export.
+- **Ops mode**: health/readiness/metrics/logging for deployment safety.
+
 - Ingestion sources:
   - Wikipedia API (`POST /ingest`)
   - Hugging Face dataset (`POST /ingest/hf`)
@@ -94,6 +101,14 @@ curl "http://localhost:8000/metrics"
 ```
 
 ## Development
+
+```bash
+make install
+make check
+make docs
+```
+
+Or run commands directly:
 
 ```bash
 uv run ruff check src tests

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,3 +18,11 @@ Minimal backend service for ingesting Wikipedia content into Neo4j and querying 
 - [API Endpoints](api/endpoints.md)
 - [Background Jobs](api/background-jobs.md)
 - [Operations & Troubleshooting](operations.md)
+
+
+## Operating modes
+
+- **Ingest**: populate graph data from Wikipedia API and HF datasets.
+- **Query**: use natural-language questions over graph context.
+- **Jobs**: run long HF ingestions asynchronously.
+- **Ops**: health, readiness, and metrics endpoints for reliability.


### PR DESCRIPTION
## Summary

Foundation PR to align project workflow and product framing with mature OSS patterns (inspired by code-graph-rag): clearer operation modes + stronger contributor workflow.

## Changes

### DevEx workflow
- Add `Makefile` targets:
  - `install`, `run`, `lint`, `typecheck`, `test`, `docs`, `check`
- Add `.pre-commit-config.yaml` with ruff + basic hygiene hooks.
- Add `.github/CODEOWNERS`.
- Add issue templates:
  - bug report
  - feature request
- Add pull request template with validation checklist.

### Product framing docs
- README: add **Modes** section (Ingest / Query / Export planned / Ops).
- README: add make-based development workflow.
- Docs home: add **Operating modes** section.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest`

All pass locally.
